### PR TITLE
Add twitter timeline

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -2,7 +2,9 @@
 layout: default
 ---
 
-<div>
+<div class="column-container">
+
+<div class="column-one">
 
   {{ content }}
 
@@ -28,3 +30,7 @@ layout: default
   </ul>
 
 </div>
+
+<div class="column-two"> <a class="twitter-timeline" data-height="1000" href="https://twitter.com/JourneesQgis?ref_src=twsrc%5Etfw">Tweets by JourneesQgis</a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script> </div></div>
+
+<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -60,6 +60,17 @@ div#contact div input, textarea, select {
     line-height: 24px;
 }
 
+.column-container{
+  display: flex;
+}
+.column-one{
+width: 80%;
+}
+.column-two{
+  width: 20%;
+  margin-left: 1em;
+  min-height: 1OOOpx;
+}
 
 @media screen and (max-width: 570px) {
     .page-header {
@@ -67,6 +78,18 @@ div#contact div input, textarea, select {
     }
     .page-header h1.project-name {
         font-size: 20px;
+    }
+}
+
+@media screen and (max-width: 42em) {
+    .column-container{
+      display: block;
+    }
+    .column-one{
+    }
+    .column-two{
+    width: 100%;
+    min-height: 1000px;
     }
 }
 

--- a/index.md
+++ b/index.md
@@ -16,5 +16,3 @@ L’événement se déroulera sur 2 jours :
 Les inscriptions ouvriront courant octobre, de même que les appels à soutien et présentations. 
 
 Suivez les actualités sur <https://twitter.com/JourneesQgis> !
-
-<div style="margin: 0 auto; width: 60%;"><a class="twitter-timeline tw-align-center" data-height="400" data-width="500" href="https://twitter.com/JourneesQgis?ref_src=twsrc%5Etfw">Tweets by JourneesQgis</a></div><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>

--- a/index.md
+++ b/index.md
@@ -16,3 +16,5 @@ L’événement se déroulera sur 2 jours :
 Les inscriptions ouvriront courant octobre, de même que les appels à soutien et présentations. 
 
 Suivez les actualités sur <https://twitter.com/JourneesQgis> !
+
+<div style="margin: 0 auto; width: 60%;"><a class="twitter-timeline tw-align-center" data-height="400" data-width="500" href="https://twitter.com/JourneesQgis?ref_src=twsrc%5Etfw">Tweets by JourneesQgis</a></div><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>


### PR DESCRIPTION
Relatif à #20 et aux discussions lors de la réunion de lancement.

Proposition d'ajouter le fil d'actualité de twitter sur le site. Cette PR l'ajoute sur la page d'accueil dans une colonne à droite lorsque l'écran le permet, comme proposé par @haubourg, sinon en bas de la page

Aperçu en grand écran : 

![image](https://user-images.githubusercontent.com/18545440/95450516-af761e00-0966-11eb-8cc1-26f4e3aeb5ac.png)


Aperçu pour petit écran et smartphone, le fil est rebasculé en bas de la page : 

![image](https://user-images.githubusercontent.com/18545440/95450424-91a8b900-0966-11eb-916f-8342245f6c8b.png)


N.B: pour ceux qui chassent les trackers de leur navigateur (comme moi), le fil d'actu est remplacé par un simple lien : 

![image](https://user-images.githubusercontent.com/18545440/95450994-6ffc0180-0967-11eb-8130-d66bfbfd8b27.png)

