### PR TITLE
Page direct

### DIFF
--- a/z20_programme.md
+++ b/z20_programme.md
@@ -8,7 +8,7 @@ menu: header
 
 ## Mardi 15 décembre - [Ateliers / Workshops] en distanciel
 
-**Les horaires sont 9h - 16h** (l'heure de fin pourra être repoussée si nécessaire).
+**Les horaires sont 9h - 17h15** (l'heure de fin pourra être repoussée si nécessaire).
 
 Les ateliers sont des séances de travail avec inscription préalable qui peuvent prendre plusieurs formes :
 

--- a/z27_direct.md
+++ b/z27_direct.md
@@ -1,0 +1,10 @@
+---
+layout: page
+title: Retransmission
+tagline: Retransmission des conférences
+menu: header
+---
+
+Vous allez être redirigé vers le site de diffusion des conférences
+
+<meta http-equiv="refresh" content="3;URL=https://rtmp-osgeo-001.cloud-ed.fr/conf/index.html"> 


### PR DESCRIPTION
Ajoute la page pour la retransmission des conférences.

Les widgets vidéos et mattermost ont des restrictions qui font qu'ils ne veulent pas s'afficher sur un autre serveur que osgeo.cloud-ed.fr. Du coup c'est une simple redirection vers le site en question.