### PR TITLE
La version hyperlien du tableau des ateliers

### DIFF
--- a/z20_programme.md
+++ b/z20_programme.md
@@ -46,9 +46,9 @@ Les ateliers dureront 1h30 ou 3h selon les besoins. Les pré-réquis éventuelle
             <td colspan=6><b>Pause</b></td>
         </tr>       <tr>
             <td><b>14:00 - 15h30</b><br><a href="#esth%C3%A9tisez-vos-cartes-issues-dosm">Esthétisez vos cartes issues d'OSM</a></td>
-            <td><b>14:00 - 15h30</b><br><a href="#les-easter-eggs--chasser-et-%C3%AAtre-chass%C3%A9">Les easter eggs de QGIS : chasser et être chassé</a></td>
-            <td><b>14:00 - 15h30</b><br><a href="#fonctionnement-du-modeleur-graphique">Fonctionnement du modeleur</a></td>
-            <td><b>14:00 - 15h30</b><br><a href="#g%C3%A9or%C3%A9f%C3%A9rencement-de-plans-anciens">Géoréférencement des plans anciens</a></td>
+            <td><b>14:00 - 15h30</b><br><a href="#les-easter-eggs-de-qgis--chasser-et-%C3%AAtre-chass%C3%A9">Les easter eggs de QGIS : chasser et être chassé</a></td>
+            <td><b>14:00 - 15h30</b><br><a href="#fonctionnement-du-modeleur-graphique">Fonctionnement du modeleur graphique</a></td>
+            <td><b>14:00 - 15h30</b><br><a href="#g%C3%A9or%C3%A9f%C3%A9rencement-de-plans-anciens">Géoréférencement de plans anciens</a></td>
             <td><b>14:00 - 15h30</b><br><a href="#r%C3%A9alisation-dune-carte-anim%C3%A9e-sur-la-base-dun-param%C3%A8tre-temporel">Réalisation d'une carte animée sur la base d'un paramètre temporel</a></td>
         </tr>
     </tbody>
@@ -259,7 +259,7 @@ Pendant cet atelier, nous verrons la publication d'un projet QGIS avec :
 * Un logiciel FTP client, tel que "Filezilla Client" https://filezilla-project.org/ pour le transfert des fichiers vers le serveur.
 * On vous communiquera avant la formation les identifiants FTP et de la base PostGIS. L'instance Lizmap sera hébergée chez 3Liz pour les besoins de la formation.
 
-## Les easter eggs : chasser et être chassé
+## Les easter eggs de QGIS : chasser et être chassé
 
 **Julien Moura (GeoTribu)**
 

--- a/z20_programme.md
+++ b/z20_programme.md
@@ -17,13 +17,42 @@ Les ateliers dureront 1h30 ou 3h selon les besoins. Les pré-réquis éventuelle
 
 **_Tous les ateliers seront accessibles uniquement en ligne._**
 
-**Les horaires sont 9h30 - 15h30**
+**Les horaires sont 9h00 - 15h30**
 
-| Horaire       | Salle "Pavin"                                                                                  | Salle "Saumon"                                                                      | Salle "Chambon"                                                                                                                                                                         | Salle "Guéry"                                                                       | Salle "Salers"                                                                                                                       | Salle "Sioule"                                           |
-| ------------- | ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------- |
-| 09:30 - 11:00 | Simplifiez-vous la vérification des plans avec QompliGIS<br><br>Loïc Bartoletti (Oslandia)<br> | Publier un projet QGIS sur le web avec Lizmap<br><br>Etienne Trimaille (3Liz)       | Comment QGIS aide à la constitution de référentiels de données géohistoriques ?<br><br>Hélène Noizet, Eric Mermet, Julien Curie (CNRS / EHESS / Consortium Huma-Num Paris Time Machine) | Gérer ses données de réseau avec QGIS/PostGIS<br><br>Alice Salsé (Be Map Guest)<br> | Déployer et maintenir des profils utilisateurs<br><br>Benoît Ducarouge et Julien Moura (Oslandia)                                     | Ateliers discussion thématique<br><br>Groupe QGIS-fr<br> |
-| 11:00 - 12:30 | Suite atelier                                                                                  | Suite atelier                                                                       | Suite atelier                                                                                                                                                                           | Suite atelier                                                                       | Création de fiches tableau de bord à partir de l'Atlas<br><br>Jacques Blenner (Agence d'urbanisme Clermont Métropole)<br>            | Suite atelier                                            |
-| 14:00 - 15:30 | Esthétisez vos cartes issues d'OSM<br><br>Alice Caron (Les Artisans cartographes)<br>          | Les easter eggs de QGIS : chasser et être chassé<br><br>Julien Moura (GeoTribu)<br> | Fonctionnement du modeleur graphique<br><br>Marjorie Fangain (Keolis) et Pierre Serafini (Sopreco)<br>                                                                                   | Géoréférencement des plans anciens<br><br>Yves Michelin (VetAgro Sup)               | Réalisation d'une carte animée sur la base d'un paramètre temporel<br><br>Sylvain Massol (Communauté d'agglomération de l'albigeois) | Suite atelier                                            |
+<table>
+    <thead>
+        <tr>
+            <th>Salle "Pavin"</th>
+            <th>Salle "Saumon"</th>
+            <th>Salle "Chambon"</th>
+            <th>Salle "Guéry"</th>
+            <th>Salle "Salers"</th>
+            <th>Salle "Sioule"</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td rowspan=2><b>09:00 - 12h00</b><br><a href="#simplifiez-vous-la-v%C3%A9rification-des-plans-avec-qompligis">Simplifiez-vous la vérification des plans avec QompliGIS</a></td>
+            <td rowspan=2><b>09:00 - 12h00</b><br><a href="#publier-un-projet-qgis-sur-le-web-avec-lizmap">Publier un projet QGIS sur le web avec Lizmap</a></td>
+            <td rowspan=2><b>09:00 - 12h00</b><br><a href="#comment-qgis-aide-%C3%A0-la-constitution-de-r%C3%A9f%C3%A9rentiels-de-donn%C3%A9es-g%C3%A9ohistoriques-">Comment QGIS aide à la constitution de référentiels de données géohistoriques ?</a></td>
+            <td rowspan=2><b>09:00 - 12h00</b><br><a href="#g%C3%A9rer-ses-donn%C3%A9es-de-r%C3%A9seau-avec-qgispostgis">Gérer ses données de réseau avec QGIS/PostGIS</a></td>
+            <td><b>09:00 - 10h30</b><br><a href="#d%C3%A9ployer-et-maintenir-des-profils-utilisateurs"> Déployer et maintenir des profils utilisateurs</a></td>
+            <td rowspan=2><b>09:00 - 12h00</b><br>Ateliers discussion thématique</td>
+        </tr>
+        <tr>
+            <td><b>10:45 - 12h15</b><br><a href="#cr%C3%A9ation-de-fiches-tableau-de-bord-%C3%A0-partir-de-latlas">Création de fiches tableau de bord à partir de l'Atlas</a></td>
+        </tr>
+         <tr>
+            <td colspan=6><b>Pause</b></td>
+        </tr>       <tr>
+            <td><b>14:00 - 15h30</b><br><a href="#esth%C3%A9tisez-vos-cartes-issues-dosm">Esthétisez vos cartes issues d'OSM</a></td>
+            <td><b>14:00 - 15h30</b><br><a href="#les-easter-eggs--chasser-et-%C3%AAtre-chass%C3%A9">Les easter eggs de QGIS : chasser et être chassé</a></td>
+            <td><b>14:00 - 15h30</b><br><a href="#fonctionnement-du-modeleur-graphique">Fonctionnement du modeleur</a></td>
+            <td><b>14:00 - 15h30</b><br><a href="#g%C3%A9or%C3%A9f%C3%A9rencement-de-plans-anciens">Géoréférencement des plans anciens</a></td>
+            <td><b>14:00 - 15h30</b><br><a href="#r%C3%A9alisation-dune-carte-anim%C3%A9e-sur-la-base-dun-param%C3%A8tre-temporel">Réalisation d'une carte animée sur la base d'un paramètre temporel</a></td>
+        </tr>
+    </tbody>
+</table>
 
 ---
 


### PR DESCRIPTION
en brut
Suffisait de trouver les bons sites pour assurer le formatage rapidement.
Par contre si quelqu'un veut bien checker... (@SebastienPeillet ?) et il faudra peut-être peaufiner le rendu.
A noter que:
- j'ai décalé le démarrage des matinées à 9h (comme l'année passée finalement) car une salle accueille deux formations dans la matinée et on n'avait pas mis de temps de ballotage entre les deux. Du coup c'est 9h-12h(15) et 14h-15h30
- j'ai gardé la colonne avec l'atelier thématique car il y a eu peu de réaction sur la suggestion de suppression de Marjorie (et si on n'enlève pas, il faudra créer une section et un lien hypertexte pour expliquer en quoi cela va consister)