### PR TITLE
Indiquer comment se rendre sur le site des journées

### DIFF
--- a/z10_localisation.md
+++ b/z10_localisation.md
@@ -5,7 +5,33 @@ tagline: Comment accéder aux Rencontres ?
 menu: header
 ---
 
-Après deux éditions à distance, les rencontres se feront en présentiel. Elles se dérouleront à l'Hôtel de Région Auvergne Rhône-Alpes, à Clermont-Ferrand avec le soutien du CRAIG. Les informations pratiques seront renseignées prochainement.
+Après deux éditions à distance, les rencontres se feront en présentiel. Elles se dérouleront à l'Hôtel de Région Auvergne Rhône-Alpes, à Clermont-Ferrand avec le soutien du CRAIG.
+
+
+<table>
+  <tr>
+    <thead colspan=2><p align=center>Se rendre à l'Hôtel de Région de Clermont-Ferrand</td>
+  </tr>
+  <tr>
+    <td><p>59 Boulevard Léon Jouhaux - CS 90706 
+63050 CLERMONT-FERRAND CEDEX 2
+T. 04 73 31 85 85
+    <br><p>S'y rendre en <b>transports en commun</b>
+      <ul> 
+        <li>Tram A / Arrêt Musée d'Art Roger Quilliot</li>
+        <li>Bus n°20 et 21 / Arrêt musée d'art Roger-Quilliot</li>
+      </ul>
+      <p>S'y rendre en <b>modes doux</b>
+      <ul> 
+        <li>A pied : 31 minutes (2,9 km) de la gare de Clermont-Ferrand / 47 minutes (3,9 km) de la place de Jaude</li>
+        <li>Station C vélo Musée d'Art Roger Quilliot</li>
+      </ul>
+    </td>
+    <td>
+      <iframe width="425" height="350" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" src="https://www.openstreetmap.org/export/embed.html?bbox=3.113363385200501%2C45.79328860609485%2C3.1201118230819707%2C45.7967034277847&amp;layer=mapnik&amp;marker=45.79499604309612%2C3.1167376041412354" style="border: 1px solid black"></iframe><br/><small><a href="https://www.openstreetmap.org/?mlat=45.79500&amp;mlon=3.11674#map=18/45.79500/3.11674">Afficher une carte plus grande</a></small>
+    </td>
+  </tr>
+ </table>
 
 
 [Retour à la page d'accueil]({{ site.url }}{{ site.baseurl }})


### PR DESCRIPTION
Ne nous voilons pas la face, ceci est un piteux draft pour ajouter les éléments de localisation de l'évenement.
Il 'inspire de l'affichage côte-à-côte "infos d'accès vs carte" comme fait à https://www.auvergnerhonealpes.fr/contenus/venir-la-region dont il reprend les infos et utilise l'iframe de Jérémy à https://gitlab.com/osgeo-fr/journees_qgis/-/issues/114#note_1149769397
J'aurais souhaité ne pas afficher les bordures de tableau et n'ai aucune idée si la carte rend quelque chose.

Heureux de laisser ceux qui savent faire prendre le lead...