### PR TITLE
Ne plus afficher le programme de 2024!

### DIFF
--- a/z20_programme.md
+++ b/z20_programme.md
@@ -1,5 +1,5 @@
 ---
-layout: page_with_program
+layout: page
 title: Programme
 tagline: L'appel à proposition est ouvert
 menu: header


### PR DESCRIPTION
Pour référence https://github.com/OSGeo-fr/QGIS-conf-fr-website/commit/6275ffbdf9dc7d108d236e2ab7b740dadf05395b#diff-3a424af498ea486b3b3bff41c2a21e4fdb20e4b6bd7cee0929576c09ae3fad71R2

Je me demande ce qu'on peut bien faire du [planning de 2024 ](https://github.com/OSGeo-fr/QGIS-conf-fr-website/tree/master/pretalx/qgis-french-users-days-2024). Ca fait quand même du bruit dans le dépôt et je ne suis pas sûr que l'idée serait d'en rajouter un chaque année...