### PR TITLE
Annonce QGIS 2026 à Brest

### DIFF
--- a/index.md
+++ b/index.md
@@ -5,7 +5,11 @@ tagline: Rencontrez, échangez, discutez autour de QGIS !
 menu: header
 ---
 
-📢 Les prochaines rencontres des utilisateurs francophones de QGIS auront lieu du **10 au 12 juin 2025 en Avignon**.
+📢***Après la Cité des Papes, les rencontres rejoindront en mars 2026 les confins du ponant à Brest où l'UMR LETG nous accueillera.***
+
+## Édition 2025
+
+Les prochaines rencontres des utilisateurs francophones de QGIS auront lieu du **10 au 12 juin 2025 en Avignon**.
 
 Co-organisées cette année avec Avignon Université et plus spécialement l'UMR 7300 ESPACE,
 les rencontres sont l'occasion de découvrir différents usages de QGIS, d'approfondir des sujets,

--- a/z10_localisation.md
+++ b/z10_localisation.md
@@ -5,9 +5,11 @@ tagline: Comment accéder aux Rencontres ?
 menu: header
 ---
 
-Les rencontres descendent le Rhône pour rejoindre la Cité des Papes avec le soutien d'Avignon Université et l'UMR 7300 ESPACE.
+Après la Cité des Papes, les rencontres rejoindront en 2026 les confins du ponant à Brest.
 
-<!-- Si vous venez de loin, n'hésitez pas à proposer un [covoiturage](https://www.covievent.org/covoiturage/rencontres-des-utilisateurs-francophones-de-qgis-edition-2023/fd0136f530d30cafbd9159e45cbc3fb1) -->
+<iframe width="425" height="350" src="https://umap.openstreetmap.fr/fr/map/qgis-fr-2026-brest_1240047" style="border: 1px solid black"></iframe><br/><small><a href="https://umap.openstreetmap.fr/fr/map/qgis-fr-2026-brest_1240047">Afficher une carte plus grande</a></small>
+
+<!-- Si vous venez de loin, n'hésitez pas à proposer un [covoiturage](https://www.covievent.org/covoiturage/rencontres-des-utilisateurs-francophones-de-qgis-edition-2024/fd0136f530d30cafbd9159e45cbc3fb1)
 
 <table>
   <tr>
@@ -26,8 +28,6 @@ Les rencontres descendent le Rhône pour rejoindre la Cité des Papes avec le so
         <li>A pied : 21 minutes (1,6 km) de la gare de d'Avignon Centre</li>
         <li>Vélo ilibre-service : 13 mn (1,7 km dont 1.3 km de voies cyclables) de la gare d'Avignon Centre</li>
       </ul>
-      <!--
-        -->
       <strong>Stationnement impossible dans l'université, <a href="https://umap.openstreetmap.fr/fr/map/avignon-universite-qgis-fr-2025_1230595#14/43.9477/4.8006">parking relais "des Italiens"</a> près du Rhône assez proche (500m)</strong>
       </p>
     </td>
@@ -37,5 +37,5 @@ Les rencontres descendent le Rhône pour rejoindre la Cité des Papes avec le so
   </tr>
  </table>
 Liaison Gare Avignon TGV - Gare Avignon Centre : en train, bus, taxi, etc. [voir les détails](https://www.rome2rio.com/fr/map/Gare-d-Avignon-TGV-Provence-Alpes-C%C3%B4te-d-Azur-France/Avignon-Centre)
-
+ -->
 [Retour à la page d'accueil]({{ site.url }}{{ site.baseurl }})


### PR DESCRIPTION
@DelazJ je pense qu'on peut annoncer tout de suite l'édition 2026 à Brest (si j'ai bien compris, cela va paraître aussi sur GeoTribu) et lancer un "save the date". 

@DelazJ , @haubourg, @GlaDal  En revanche je suis pour laisser tout ce qui concerne Avignon jusqu'en septembre. À voir lors de la réunion de bilan, qu'en pensez-vous ?