### PR TITLE
Ajout liens markdown videos et supports confs Avignon

### DIFF
--- a/_posts/2025-07-08-publication-videos-conferences.md
+++ b/_posts/2025-07-08-publication-videos-conferences.md
@@ -8,5 +8,5 @@ Les 12 conférences des dernières Rencontres QGIS-fr d'Avignon, le 11 Juin dern
 
 Vous pourrez y découvrir des cas d'usage et stratégies autour de QGIS, présentés par les conférencier/es de cette année.
 
-- playlist sur PeerTube : https://video.osgeo.org/w/p/6FaxCxrrfstpaAoxzVH5dZ
-- les PDF des présentations: https://gitlab.com/osgeo-fr/journees_qgis/-/tree/master/Pr%C3%A9sentations/2025
+- playlist sur PeerTube : [QGISFR2025 - Avignon](https://video.osgeo.org/w/p/6FaxCxrrfstpaAoxzVH5dZ)
+- les PDF des présentations: [dossier GitLab](https://gitlab.com/osgeo-fr/journees_qgis/-/tree/master/Pr%C3%A9sentations/2025)


### PR DESCRIPTION
En fait ça fait un peu bizarre d'avoir à copier-coller les liens :s

![image](https://github.com/user-attachments/assets/222b3cc4-8bed-4851-a600-41de76b74f3c)

Je crois que c'est plus simple si on peut cliquer sur un lien markdown, tout simplement.